### PR TITLE
Multiple category selections

### DIFF
--- a/third_party/wb_category_select/language/english/lang.wb_category_select.php
+++ b/third_party/wb_category_select/language/english/lang.wb_category_select.php
@@ -3,6 +3,7 @@
 $lang = array(
 
 'wb_category_select_groups'  => 'Category Groups',
+'wb_category_select_multi' => 'Allow multiple selections?',
 
 ''=>''
 );


### PR DESCRIPTION
Hey Wes,

Someone had the need to select multiple categories per each Matrix row. I figured rather than reinvent the wheel, I’d just add the feature to your add-on. This change is composed of a new “Multiple Selections?” field setting (Yes/No radios), and a new tag pair mode, in the event that multiple selections are enabled:

{wb_category_field}
  {category_id}
{/wb_category_field}
