### PR TITLE
Changed evaluation of $tagdata in replace_tag()

### DIFF
--- a/third_party/wb_category_select/ft.wb_category_select.php
+++ b/third_party/wb_category_select/ft.wb_category_select.php
@@ -304,7 +304,7 @@ class Wb_category_select_ft extends EE_Fieldtype {
 		}
 		
 		// check for tagdata, if no tagdata, spit out a pipe separated list of the category ids
-		if ($tagdata === FALSE)
+		if (!$tagdata)
 		{
 			$categories = array();
 			


### PR DESCRIPTION
$tagdata === FALSE wasn't evaluating as expected for no tagdata, resulting in no output from the tag. Changed to the less strict !$tagdata.
